### PR TITLE
Allow S3 deploy + Common JS CI/CD workflows to force download dependencies

### DIFF
--- a/.github/workflows/aws-s3-deployment.yml
+++ b/.github/workflows/aws-s3-deployment.yml
@@ -24,6 +24,14 @@ on:
           in the `conditional-outputs` action to set the build suffix and other
           environment-specific settings.
         required: true
+      force-ignore-dependency-warnings:
+        type: boolean
+        description: |
+          Use `--force` when installing dependencies to ignore peer dependency
+          warnings. This is useful when using packages that have not yet updated
+          their peer dependencies to include support for newer libraries.
+        required: false
+        default: false
       node-version:
         type: string
         description: |
@@ -125,7 +133,7 @@ jobs:
           NEXT_PUBLIC_REPORTING_API_KEY: ${{ secrets.reporting-api-key }}
           WEBSITE_HOST: ${{ needs.determine-environment.outputs.website }}
         run: |
-          npm ci
+          npm ci ${{ inputs.force-ignore-dependency-warnings == true && '--force' || '' }}
           npm run build:${{ needs.determine-environment.outputs.build-suffix }}
 
           if [ -n "${{ secrets.reporting-api-key }}" ]; then

--- a/.github/workflows/common-ci-js.yml
+++ b/.github/workflows/common-ci-js.yml
@@ -29,6 +29,14 @@ on:
         description: Disable the unit testing job
         required: false
         default: false
+      force-ignore-dependency-warnings:
+        type: boolean
+        description: |
+          Use `--force` when installing dependencies to ignore peer dependency
+          warnings. This is useful when using packages that have not yet updated
+          their peer dependencies to include support for newer libraries.
+        required: false
+        default: false
       node-version:
         type: string
         description: |
@@ -71,7 +79,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.node-auth-token }}
         run: |
-          npm ci
+          npm ci ${{ inputs.force-ignore-dependency-warnings == true && '--force' || '' }}
           npm run ${{ inputs.build-script }}
           npm run lint
 
@@ -95,7 +103,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.node-auth-token }}
         run: |
-          npm ci
+          npm ci ${{ inputs.force-ignore-dependency-warnings == true && '--force' || '' }}
           npm run ${{ inputs.build-script }}
           npm run format
           git diff --exit-code
@@ -120,6 +128,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.node-auth-token }}
         run: |
-          npm ci
+          npm ci ${{ inputs.force-ignore-dependency-warnings == true && '--force' || '' }}
           npm run ${{ inputs.build-script }}
           npm run test


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows (`aws-s3-deployment.yml` and `common-ci-js.yml`) to add an option for ignoring peer dependency warnings when installing Node.js dependencies. This is achieved by allowing the use of the `--force` flag with `npm ci` via a new input parameter. This helps workflows succeed even when some dependencies have not updated their peer dependencies for newer libraries.

**New input for dependency installation:**

* Added a `force-ignore-dependency-warnings` boolean input to both `.github/workflows/aws-s3-deployment.yml` and `.github/workflows/common-ci-js.yml`, allowing jobs to opt in to using the `--force` flag during `npm ci` to bypass peer dependency warnings.